### PR TITLE
AddAndCount and RemoveAndCount methods added to ConnectionGrain

### DIFF
--- a/src/Orleans.SignalR/Core/ConnectionGrain.cs
+++ b/src/Orleans.SignalR/Core/ConnectionGrain.cs
@@ -1,12 +1,11 @@
-﻿using System.Buffers;
+﻿using Microsoft.AspNetCore.SignalR.Protocol;
+using Microsoft.Extensions.Logging;
+using Orleans.Concurrency;
+using Orleans.Streams;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.SignalR.Protocol;
-using Microsoft.Extensions.Logging;
-using Orleans;
-using Orleans.Concurrency;
-using Orleans.Streams;
 
 namespace Orleans.SignalR.Core
 {
@@ -44,7 +43,7 @@ namespace Orleans.SignalR.Core
 
         public virtual async Task Add(string connectionId)
         {
-            var shouldWriteState = State.Connections.Add(connectionId);
+            var isAdded = State.Connections.Add(connectionId);
             if (!_connectionStreamHandles.ContainsKey(connectionId))
             {
                 var clientDisconnectStream = _streamProvider.GetStream<string>(SignalrConstants.CLIENT_DISCONNECT_STREAM_ID, connectionId);
@@ -52,13 +51,29 @@ namespace Orleans.SignalR.Core
                 _connectionStreamHandles[connectionId] = subscription;
             }
 
-            if (shouldWriteState)
+            if (isAdded)
                 await WriteStateAsync();
+        }
+
+        public virtual async Task<(bool IsAdded, int TotalCount)> AddAndCount(string connectionId)
+        {
+            var isAdded = State.Connections.Add(connectionId);
+            if (!_connectionStreamHandles.ContainsKey(connectionId))
+            {
+                var clientDisconnectStream = _streamProvider.GetStream<string>(SignalrConstants.CLIENT_DISCONNECT_STREAM_ID, connectionId);
+                var subscription = await clientDisconnectStream.SubscribeAsync(async (connId, _) => await Remove(connId));
+                _connectionStreamHandles[connectionId] = subscription;
+            }
+
+            if (isAdded)
+                await WriteStateAsync();
+
+            return (IsAdded: isAdded, TotalCount: State.Connections.Count);
         }
 
         public virtual async Task Remove(string connectionId)
         {
-            var shouldWriteState = State.Connections.Remove(connectionId);
+            var isRemoved = State.Connections.Remove(connectionId);
             if (_connectionStreamHandles.TryGetValue(connectionId, out var stream))
             {
                 await stream.UnsubscribeAsync();
@@ -70,10 +85,32 @@ namespace Orleans.SignalR.Core
                 await ClearStateAsync();
                 DeactivateOnIdle();
             }
-            else if (shouldWriteState)
+            else if (isRemoved)
             {
                 await WriteStateAsync();
             }
+        }
+
+        public virtual async Task<(bool IsRemoved, int TotalCount)> RemoveAndCount(string connectionId)
+        {
+            var isRemoved = State.Connections.Remove(connectionId);
+            if (_connectionStreamHandles.TryGetValue(connectionId, out var stream))
+            {
+                await stream.UnsubscribeAsync();
+                _connectionStreamHandles.Remove(connectionId);
+            }
+
+            if (State.Connections.Count == 0)
+            {
+                await ClearStateAsync();
+                DeactivateOnIdle();
+            }
+            else if (isRemoved)
+            {
+                await WriteStateAsync();
+            }
+
+            return (IsRemoved: isRemoved, TotalCount: State.Connections.Count);
         }
 
         public virtual Task Send(Immutable<InvocationMessage> message)

--- a/src/Orleans.SignalR/Core/IConnectionGrain.cs
+++ b/src/Orleans.SignalR/Core/IConnectionGrain.cs
@@ -16,10 +16,24 @@ namespace Orleans.SignalR.Core
         Task Add(string connectionId);
 
         /// <summary>
+        /// Add connection id to the group.
+        /// </summary>
+        /// <param name="connectionId">Connection id to add.</param>
+        /// <returns>If connection id was added successfully and total number of connectionIds</returns>
+        Task<(bool IsAdded, int TotalCount)> AddAndCount(string connectionId);
+
+        /// <summary>
         /// Remove the connection id to the group.
         /// </summary>
         /// <param name="connectionId">Connection id to remove.</param>
         Task Remove(string connectionId);
+
+        /// <summary>
+        /// Remove the connection id to the group.
+        /// </summary>
+        /// <param name="connectionId">Connection id to remove.</param>
+        /// <returns>If connection id was added successfully and total number of connectionIds</returns>
+        Task<(bool IsRemoved, int TotalCount)> RemoveAndCount(string connectionId);
 
         /// <summary>
         /// Gets the connection count in the group.
@@ -33,5 +47,6 @@ namespace Orleans.SignalR.Core
         /// <param name="args">Arguments to pass to the target method.</param>
         /// <param name="excludedConnectionIds">Connection ids to exclude.</param>
         Task SendExcept(string methodName, object[] args, IReadOnlyList<string> excludedConnectionIds);
+        
     }
 }


### PR DESCRIPTION
The purpose of this PR is to add logic that makes it easier to handle scenarios where we want to set a user/player as online/offline based on when the number of connections in a group goes from 0 to 1 or from 1 to 0.

Since the code change is done in ConnectionGrain, it will also add the feature to ClientGrain.

